### PR TITLE
Chinese Translation Typo Correction

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -38,9 +38,9 @@
     <string name="status_label">状态:</string>
     <string name="battery_info_label">信息:</string>
     <string name="enable_cooldown">启用冷却:</string>
-    <string name="cooldown_capacity">开始冷却阀值:</string>
-    <string name="resume_charge">恢复充电阀值:</string>
-    <string name="stop_charge">停止充电阀值:</string>
+    <string name="cooldown_capacity">开始冷却阈值:</string>
+    <string name="resume_charge">恢复充电阈值:</string>
+    <string name="stop_charge">停止充电阈值:</string>
     <string name="enable_temp_check">启用温控 (°C)</string>
     <string name="cooldown_temp">开始冷却温度:</string>
     <string name="max_temp">最高温度:</string>


### PR DESCRIPTION
“阀值” in the original file is in fact a mis-reading and mis-spell of "阈值"("threshold")
another translation ("门槛值") is also acceptable.